### PR TITLE
Add touchstart event to fix touch/mobile issue

### DIFF
--- a/product.liquid
+++ b/product.liquid
@@ -32,7 +32,7 @@ Place this in your product.liquid template, at the bottom.
     $(function() {
       thumbnails = $('img[src*="/products/"]').not(':first');
       if (thumbnails.size()) {
-        thumbnails.bind('click', function() {
+        thumbnails.bind('click touchstart', function() {
           var image = $(this).attr('src').split('?')[0].replace(/(_thumb\.)|(_small\.)|(_compact\.)|(_medium\.)|(_large\.)|(_grande\.)/,'.');
           if (typeof variantImages[image] !== 'undefined') {
             {% for option in product.options %}


### PR DESCRIPTION
This fixes issue #1 where the snippet does not work on mobile devices regardless of the theme being used.  Adding touchstart in addition to click will enable this to work on touch devices.
